### PR TITLE
Added option -  DontUseSpawnEffect

### DIFF
--- a/lua/entities/npc_decentvehicle/init.lua
+++ b/lua/entities/npc_decentvehicle/init.lua
@@ -968,7 +968,9 @@ function ENT:Initialize()
 
 	local e = EffectData()
 	e:SetEntity(self.v)
-	util.Effect("propspawn", e) -- Perform a spawn effect.
+	if not self.DontUseSpawnEffect then
+		util.Effect("propspawn", e) -- Perform a spawn effect.
+	end
 	self:AttachModel()
 	self:DrawShadow(false)
 	self:GetVehicleParams()

--- a/lua/entities/npc_decentvehicle/init.lua
+++ b/lua/entities/npc_decentvehicle/init.lua
@@ -1065,7 +1065,9 @@ function ENT:OnRemove()
 
 	local e = EffectData()
 	e:SetEntity(self.v)
-	util.Effect("propspawn", e) -- Perform a spawn effect.
+	if not self.DontUseSpawnEffect then
+		util.Effect("propspawn", e) -- Perform a spawn effect.
+	end
 end
 
 if VCModFixedAroundNPCDriver then return end -- WORKAROUND!!!


### PR DESCRIPTION
Hello. I am the developer of the "Background NPCs" addon. I would like to be able to not use the spawn effect when creating the AI. Could you please confirm this request?